### PR TITLE
Add control to hide read activities

### DIFF
--- a/src/components/VActivity.vue
+++ b/src/components/VActivity.vue
@@ -41,7 +41,11 @@ const isFiltered = useIsFiltered(props.activity)
 			hasRead && $style.read,
 			!isFiltered && $style.hidden,
 		]"
-		v-show="!hideRead || (hideRead && !hasRead)"
+		v-show="
+			!hideRead ||
+			(hideRead &&
+				!hasRead) /* @todo: Move this to a filter before undrafting PR. */
+		"
 	>
 		<div :class="$style.actions">
 			<IconComponent :class="$style.icon" />

--- a/src/components/VHideMarkedAsRead.vue
+++ b/src/components/VHideMarkedAsRead.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { toggleHidingRead, hideRead } from "../composables/hide-read"
+</script>
+
+<template>
+	<button @click.prevent="toggleHidingRead" type="button">
+		{{ hideRead ? "Show" : "Hide" }} read activities
+	</button>
+</template>

--- a/src/components/VMarkAllAsRead.vue
+++ b/src/components/VMarkAllAsRead.vue
@@ -3,7 +3,7 @@ import { ref } from "vue"
 import { allActivities } from "../composables/pulls"
 import { markAsRead, hasRead } from "../composables/read"
 
-const isCaughtUp = ref(allActivities().map(hasRead).every(Boolean))
+const isCaughtUp = ref(allActivities().map(hasRead).some(Boolean))
 
 const markAllAsRead = () => {
 	markAsRead(allActivities())

--- a/src/composables/hide-read.ts
+++ b/src/composables/hide-read.ts
@@ -1,8 +1,7 @@
-import type { Activity } from "./pulls"
 import { useStorage } from "./use-storage"
 
 export const hideRead = useStorage<Boolean>("overvue:hide-read", false)
 
-export const toggleHidingRead = (activities: Activity[]) => {
+export const toggleHidingRead = () => {
 	hideRead.value = !hideRead.value
 }

--- a/src/composables/hide-read.ts
+++ b/src/composables/hide-read.ts
@@ -1,0 +1,8 @@
+import type { Activity } from "./pulls"
+import { useStorage } from "./use-storage"
+
+export const hideRead = useStorage<Boolean>("overvue:hide-read", false)
+
+export const toggleHidingRead = (activities: Activity[]) => {
+	hideRead.value = !hideRead.value
+}


### PR DESCRIPTION
Adds a button to toggle the visibility of read activities. 
Also adds some light styles to group the control buttons above the header in a row.

Finally, I believe I fixed the logic of the `VMarkAllAsRead` button to show the "You're all caught up!" message on initial page load if all items are marked read.